### PR TITLE
feat!: named repositories in config for better overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,24 +21,30 @@ $ ./yaml-updater update --help
 
 ### Update a yaml via flags only
 
+> **NOTE:** For more complex (or multiple) targets, it is recommended to use a "repositories" configuration file ([see below](#use-yaml-configuration)).
+
 ```shell
 $ export GIT_USERNAME=my-user GIT_AUTH_TOKEN=my_token
-$ ./yaml-updater update --file-path service-a/deployment.yaml --change-source-name my-docker-code-repo --source-repo my-org/my-change-target-repo --source-branch master --new-value quay.io/myorg/my-image:v1.1.0 --update-key spec.template.spec.containers.0.image --branch-generate-name gitops- 
+$ ./yaml-updater update --file-path service-a/deployment.yaml --change-source-name my-docker-code-repo --source-repo my-org/my-change-target-repo --source-branch master --update-key spec.template.spec.containers.0.image --branch-generate-name gitops- --new-value quay.io/myorg/my-image:v1.1.0
 ```
 
-This would update a file `service-a/deployment.yaml` in a GitHub repository at `my-org/my-change-target-repo`, changing the `spec.template.spec.containers.0.image` key in the file to `quay.io/myorg/my-image:v1.1.0`, the PR will indicate that this is an update from `my-docker-code-repo`.
+This would create a new branch `gitops-[random]` from current master HEAD in a GitHub repository `my-org/my-change-target-repo`, and update the file `service-a/deployment.yaml` by changing the `spec.template.spec.containers.0.image` key in the file to `quay.io/myorg/my-image:v1.1.0`, creating a PR against master that would include a message `Automatic update from my-docker-code-repo`.
 If you want to do the same for some of the other supported git services, set GIT_DRIVER: `GIT_DRIVER=bitbucketcloud` or `GIT_DRIVER=gitlab`
 
 If you need to access to private GitLab or GitHub installation, you can provide the `--api-endpoint` flag (or use the corresponding `GIT_API_ENDPOINT` env variable)
 
+To disable PR creation and commit directly to the `--source-branch` value, simply pass `--disable-pr-creation` (and make sure the source branch can be committed directly to).
+For additional details, see below [Important: Updating the sourceBranch directly](#important-updating-the-sourcebranch-directly).
+
 ### Use yaml configuration
 
-This allows one to simplify calling the cli or to apply the same value change to multiple files or repositories. For example, for CI/CD pipelines it's simpler to write most of the update command flags as configuration, and provide it as a list of repository details to target changes, which as mentioned also supports targeting multiple repositories or files (if the repository details are the same).
+The repositories config allows one to simplify calling the cli, or to apply the same value change to multiple files, branches or repositories. For example, for CI/CD pipelines it's simpler to write most of the update command flags as configuration, and provide it as a list of repository details to target changes, which as mentioned, also supports targeting multiple repositories or files (if the repository details are the same).
 For example, the above section cli command could be simplified, so that the configuration would look like
 
 ```yaml
 repositories:
-  - name: my-docker-code-repo
+  my-repository:
+    name: my-docker-code-repo
     sourceRepo: my-org/my-change-target-repo
     sourceBranch: master
     filePath: service-a/deployment.yaml
@@ -52,14 +58,80 @@ $ export GIT_USERNAME=my-user GIT_AUTH_TOKEN=my_token
 $ ./yaml-updater update --new-value quay.io/myorg/my-image:v1.1.0
 ```
 
-The yaml configuration can be a relative or absolute path and be set with the `--config-path` flag or the `GIT_CONFIG_PATH` env var, and defaults to '.yaml-updater.yaml' when not set.
+The repositories yaml configuration itself can be a relative or absolute path and be set with the `--config-path` flag or the `GIT_CONFIG_PATH` env var, and defaults to '.yaml-updater.yaml' when not set. 
 
-Do note that, when using the configuration yaml, neither `--username`, `--driver` or `--auth-token` have a corresponding configuration field, as these are globally set and not particular to any repository.
-Likewise, every root or update command flag can be set as an env var of the form `GIT_` + the flag name with the dash replaced by an underscore and in uppercase. In the case of these flags, they were passed as env vars as they'll most likely be reused, but if not, call the updater and set them as flags instead.
-No need to set the driver if using `github`, which is the default.
+> Do note that, when using the configuration yaml, neither `--username`, `--driver` or `--auth-token` have a corresponding configuration field, as these are globally set and not particular to any repository.
+> Likewise, every root or update command flag can be set as an env var of the form `GIT_` + the flag name with the dash replaced by an underscore and in uppercase. In the case of these flags, they were passed as env vars as they'll most likely be reused, but if not, call the updater and set them as flags instead.
+> No need to set the driver if using `github`, which is the default.
+
+In the above example, the `--new-value` `quay.io/myorg/my-image:v1.1.0` would be applied just as in the CLI example above. The main difference with this approach is that a project could configure multiple targets (i.e. different repositories, branches, files or even yaml keys) updated with the same value in one go (as long as the git service and the credentials are common!). 
+
+For example, a config file could look like:
+
+```yaml
+repositories:
+  prod:
+    disabled: true
+    name: my-docker-code-repo
+    sourceRepo: my-org/my-change-target-repo
+    sourceBranch: master
+    filePath: service-a/deployment.yaml
+    updateKey: spec.template.spec.containers.0.image
+    branchGenerateName: gitops-
+  dev:
+    name: my-docker-code-repo
+    sourceRepo: my-org/my-change-target-repo
+    sourceBranch: dev
+    filePath: service-a/deployment.yaml
+    updateKey: spec.template.spec.containers.0.image
+    disablePRCreation: true
+```
+
+And then call the updater regularly like:
+
+```shell
+$ export GIT_USERNAME=my-user GIT_AUTH_TOKEN=my_token
+$ ./yaml-updater update --new-value [my-new-image-value]
+```
+
+but when targeting production, something like
+
+```shell
+$ export GIT_USERNAME=my-user GIT_AUTH_TOKEN=my_token
+$ ./yaml-updater update --new-value [my-new-image-value] --only prod
+```
+
+This would ensure that development changes are automatically committed, not creating PRs to master (first command) while creating a PR for master and not modifying dev if executing the second.
+
+> A third variation could be 
+> ```shell
+> $ export GIT_USERNAME=my-user GIT_AUTH_TOKEN=my_token
+> $ ./yaml-updater update --new-value [my-new-image-value] --override-repositories "prod,dev" --disabled=false
+> ```
+> which would cause both to be enabled (overrides the `disable` key in both so effectively enabling them) and so it'd commit directly to dev and create a PR for master from branch `gitops-[random]`. 
+
+
+For more options and uses, see the section below on [Yaml configuration overrides](#yaml-configuration-overrides).
+
+
+### Yaml configuration overrides
+
+If the config file exists and has repositories, command line flags can operate as overrides provided that the action is explicitly enabled (applied to **ALL** targeted repositories, though only effective on enabled repositories, unless the override is the `--disabled=false` flag). yaml-updater provides 3 flags for that:
+
+1. `--override-all` (Boolean): As indicated by the name, if passes, any repository config passed via CLI will override every configured repository defined in config with the given value. 
+2. `--override-repositories` (String): This is a comma separated list of matching repository config keys so that repository config passed via CLI will override every matched configured repository with the given value.
+3. `--only` (String): This is also a comma separated list of matching repository config keys so that repository config passed via CLI will override every matched configured repository with the given value AND every matching repository will be enabled plus any NON matching key will be removed and not used at all.
+
+> :warning: Using `only` has a slightly different semantics than the other 2 flags in that it will disable (remove) any repository not given in the `--only` flag.
+
+> See `yaml-updater update --help` for additional details. 
 
 
 ### Important: Updating the sourceBranch directly
+
+By default, changes are not committed directly, by via a PR with a branch whose name is prefixed with the value of `branchGenerateName` (`gitops-` by default).
+To commit directly, make sure to either set `disablePRCreation` to `true` in the spec, or pass the corresponding `--disable-pr-creation` flag to the command.
+*NOTE:* This is meant to work with `--override-repository [repo-config-key]`. If no such flag is passed, and `yaml-updater` detects more than one repository being updated, the command will fail, unless the `-override-all` (Boolean) flag is passed.
 
 If no value is provided for `branchGenerateName`, then the `sourceBranch` will be updated directly, this means that if you use `master`, there will not be a PR created, the commit will be applied directly, and the token needs to authorize access to push a change directly to `master`.
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-logr/zapr v1.2.2
 	github.com/google/go-cmp v0.5.7
 	github.com/ocraviotto/go-scm v1.19.1
-	github.com/ocraviotto/pkg v0.1.1
+	github.com/ocraviotto/pkg v0.2.0
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/viper v1.10.1
 	go.uber.org/zap v1.20.0
@@ -16,7 +16,40 @@ require (
 )
 
 require (
+	code.gitea.io/sdk/gitea v0.15.1 // indirect
+	github.com/benbjohnson/clock v1.1.0 // indirect
+	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/hashicorp/go-version v1.3.0 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/spf13/afero v1.6.0 // indirect
+	github.com/spf13/cast v1.4.1 // indirect
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/tidwall/gjson v1.12.1 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
+	github.com/tidwall/sjson v1.2.4 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d // indirect
+	golang.org/x/sys v0.0.0-20211210111614-af8b64212486 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/ini.v1 v1.66.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	k8s.io/klog v1.0.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v3 v3.0.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -440,8 +440,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/ocraviotto/go-scm v1.19.1 h1:2MwH1CB+xeoO1Iyw5mK+JZeqsJxyrBt+RBVmhZxPYyI=
 github.com/ocraviotto/go-scm v1.19.1/go.mod h1:JiAUoxUMB0kCNz3j2vPbCObNbaclD11YWfOAJVuzpe0=
-github.com/ocraviotto/pkg v0.1.1 h1:WKEFRV/Ik8/6FlQNVX0XcFOocXN8+aDDdTmxZDhnOnU=
-github.com/ocraviotto/pkg v0.1.1/go.mod h1:frDGdJ8tP8Nxw7Him4PD3Quz6wa24Xm55hW+ilIAyd4=
+github.com/ocraviotto/pkg v0.2.0 h1:MtsFUNWNTVmzCogaoHB1Yy9YY07VtePQXG5DhFnTMuo=
+github.com/ocraviotto/pkg v0.2.0/go.mod h1:frDGdJ8tP8Nxw7Him4PD3Quz6wa24Xm55hW+ilIAyd4=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -35,7 +35,7 @@ func makeRootCmd() *cobra.Command {
 
 	cmd.PersistentFlags().String(
 		driverFlag,
-		"bitbucketcloud",
+		"github",
 		"go-scm driver name to use e.g. github, gitlab, bitbucket, bitbucketcloud",
 	)
 	logIfError(viper.BindPFlag(driverFlag, cmd.PersistentFlags().Lookup(driverFlag)))

--- a/pkg/cmd/testdata/base-repositories.yaml
+++ b/pkg/cmd/testdata/base-repositories.yaml
@@ -11,12 +11,22 @@ repositories:
       name: "John Doe"
       email: "john.doe@example.com"
   testRepo2:
-    name: testing/repo-image
+    name: testing/repo-image2
     sourceRepo: my-org/my-other-project
     sourceBranch: master
-    filePath: service-a/deployment.yaml
-    updateKey: spec.template.spec.containers.0.image
-    branchGenerateName: repo-imager-
+    filePath: service-b/pod.yaml
+    updateKey: spec.containers.0.image
+    createMissing: true
+    signature:
+      name: "John Doe"
+      email: "john.doe@example.com"
+  testRepo3:
+    disabled: true
+    name: testing/another-repo
+    sourceRepo: my-org/my-other-project
+    sourceBranch: master
+    filePath: argocd/application.yaml
+    updateKey: spec.source.targetRevision
     createMissing: true
     signature:
       name: "John Doe"

--- a/pkg/cmd/testdata/single-repository.yaml
+++ b/pkg/cmd/testdata/single-repository.yaml
@@ -10,14 +10,3 @@ repositories:
     signature:
       name: "John Doe"
       email: "john.doe@example.com"
-  testRepo2:
-    name: testing/repo-image
-    sourceRepo: my-org/my-other-project
-    sourceBranch: master
-    filePath: service-a/deployment.yaml
-    updateKey: spec.template.spec.containers.0.image
-    branchGenerateName: repo-imager-
-    createMissing: true
-    signature:
-      name: "John Doe"
-      email: "john.doe@example.com"

--- a/pkg/cmd/update_test.go
+++ b/pkg/cmd/update_test.go
@@ -1,0 +1,292 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/ocraviotto/yaml-updater/pkg/config"
+	"github.com/spf13/viper"
+)
+
+type testFlags map[string]interface{}
+
+func TestOverrides(t *testing.T) {
+	s := &config.Signature{
+		Name:  "John Doe",
+		Email: "john.doe@example.com",
+	}
+	parseTests := []struct {
+		testName string
+		filename string
+		flags    *testFlags
+		want     *config.RepoConfiguration
+	}{
+		{
+			"testOverrideRepositories",
+			"testdata/base-repositories.yaml",
+			&testFlags{
+				"override-repositories": "testRepo1,testRepo2",
+				"disabled":              true,
+			},
+			&config.RepoConfiguration{
+				Repositories: map[string]*config.Repository{},
+			},
+		},
+		{
+			"testOverridesAll",
+			"testdata/base-repositories.yaml",
+			&testFlags{
+				"override-all": true,
+				"disabled":     true,
+			},
+			&config.RepoConfiguration{
+				Repositories: map[string]*config.Repository{},
+			},
+		},
+		{
+			"testOnlyWithOverrides",
+			"testdata/base-repositories.yaml",
+			&testFlags{
+				"only":                 "testRepo3",
+				"disabled":             true,
+				"source-branch":        "branch3",
+				"create-missing":       false,
+				"branch-generate-name": "",
+				"committer-name":       "Doe, John",
+			},
+			&config.RepoConfiguration{
+				Repositories: map[string]*config.Repository{
+					"testRepo3": {
+						Disabled:           false,
+						Name:               "testing/another-repo",
+						SourceRepo:         "my-org/my-other-project",
+						SourceBranch:       "branch3",
+						FilePath:           "argocd/application.yaml",
+						UpdateKey:          "spec.source.targetRevision",
+						BranchGenerateName: "",
+						Signature: &config.Signature{
+							Name:  "Doe, John",
+							Email: "john.doe@example.com",
+						},
+					},
+				},
+			},
+		},
+		{
+			"testNoOverridesSingleRepoInConfig",
+			"testdata/single-repository.yaml",
+			&testFlags{
+				"source-branch":       "direct",
+				"disable-pr-creation": true,
+			},
+			&config.RepoConfiguration{
+				Repositories: map[string]*config.Repository{
+					"testRepo1": {
+						Name:               "testing/repo-image",
+						SourceRepo:         "my-org/my-project",
+						SourceBranch:       "main",
+						FilePath:           "service-a/deployment.yaml",
+						UpdateKey:          "spec.template.spec.containers.0.image",
+						BranchGenerateName: "repo-imager-",
+						DisablePRCreation:  false,
+						CreateMissing:      true,
+						Signature:          s,
+					},
+				},
+			},
+		},
+		{
+			"testOverridesAll",
+			"testdata/base-repositories.yaml",
+			&testFlags{
+				"override-all": true,
+				"disabled":     false,
+			},
+			&config.RepoConfiguration{
+				Repositories: map[string]*config.Repository{
+					"testRepo1": {
+						Name:               "testing/repo-image",
+						SourceRepo:         "my-org/my-project",
+						SourceBranch:       "main",
+						FilePath:           "service-a/deployment.yaml",
+						UpdateKey:          "spec.template.spec.containers.0.image",
+						BranchGenerateName: "repo-imager-",
+						CreateMissing:      true,
+						Signature:          s,
+					},
+					"testRepo2": {
+						Name:               "testing/repo-image2",
+						SourceRepo:         "my-org/my-other-project",
+						SourceBranch:       "master",
+						FilePath:           "service-b/pod.yaml",
+						UpdateKey:          "spec.containers.0.image",
+						BranchGenerateName: "",
+						CreateMissing:      true,
+						Signature:          s,
+					},
+					"testRepo3": {
+						Name:               "testing/another-repo",
+						SourceRepo:         "my-org/my-other-project",
+						SourceBranch:       "master",
+						FilePath:           "argocd/application.yaml",
+						UpdateKey:          "spec.source.targetRevision",
+						BranchGenerateName: "",
+						CreateMissing:      true,
+						Signature:          s,
+					},
+				},
+			},
+		},
+		{
+			"testOverridesGen",
+			"testdata/base-repositories.yaml",
+			&testFlags{
+				"override-repositories": "testRepo2,testRepo3",
+				"source-branch":         "direct",
+				"disable-pr-creation":   true,
+			},
+			&config.RepoConfiguration{
+				Repositories: map[string]*config.Repository{
+					"testRepo1": {
+						Name:               "testing/repo-image",
+						SourceRepo:         "my-org/my-project",
+						SourceBranch:       "main",
+						FilePath:           "service-a/deployment.yaml",
+						UpdateKey:          "spec.template.spec.containers.0.image",
+						BranchGenerateName: "repo-imager-",
+						CreateMissing:      true,
+						Signature:          s,
+					},
+					"testRepo2": {
+						Name:               "testing/repo-image2",
+						SourceRepo:         "my-org/my-other-project",
+						SourceBranch:       "direct",
+						FilePath:           "service-b/pod.yaml",
+						UpdateKey:          "spec.containers.0.image",
+						BranchGenerateName: "",
+						DisablePRCreation:  true,
+						CreateMissing:      true,
+						Signature:          s,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range parseTests {
+		t.Run(fmt.Sprintf("parsing %s", tt.filename), func(rt *testing.T) {
+			initViper()
+			makeUpdateCmd()
+			repositories := loadRepositoriesFromFile(tt.filename, rt)
+
+			setViperFromTestFlags(tt.flags)
+
+			got, err := processConfigsAndOverrides(repositories)
+			if err != nil {
+				t.Fatalf("error with applyConfigsOverrides %#v", err)
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				rt.Errorf("Test %s (loading %s) failed diff\n%s", tt.testName, tt.filename, diff)
+			}
+		})
+	}
+}
+
+func TestConfigFromFlags(t *testing.T) {
+	s := &config.Signature{
+		Name:  "John Doe",
+		Email: "john.doe@example.com",
+	}
+	parseTests := []struct {
+		testName string
+		flags    *testFlags
+		want     *config.Repository
+	}{
+		{
+			"testDisablePR",
+			&testFlags{
+				"image-repo":     "testing/another-repo",
+				"source-repo":    "my-org/my-other-project",
+				"source-branch":  "branch3",
+				"file-path":      "argocd/application.yaml",
+				"update-key":     "spec.source.targetRevision",
+				"create-missing": false,
+				"disabled":       true,
+			},
+			&config.Repository{
+				Disabled:           false,
+				Name:               "testing/another-repo",
+				SourceRepo:         "my-org/my-other-project",
+				SourceBranch:       "branch3",
+				BranchGenerateName: "gitops-",
+				FilePath:           "argocd/application.yaml",
+				UpdateKey:          "spec.source.targetRevision",
+				Signature:          &config.Signature{},
+			},
+		}, {
+			"testWithOverrides",
+			&testFlags{
+				"change-source-name":  "testing/another-repo",
+				"source-repo":         "my-org/my-other-project",
+				"source-branch":       "branch3",
+				"file-path":           "argocd/application.yaml",
+				"update-key":          "spec.source.targetRevision",
+				"committer-name":      "John Doe",
+				"committer-email":     "john.doe@example.com",
+				"commit-msg":          "hello from my PR",
+				"disable-pr-creation": true,
+			},
+			&config.Repository{
+				Disabled:           false,
+				Name:               "testing/another-repo",
+				SourceRepo:         "my-org/my-other-project",
+				SourceBranch:       "branch3",
+				BranchGenerateName: "gitops-",
+				FilePath:           "argocd/application.yaml",
+				UpdateKey:          "spec.source.targetRevision",
+				DisablePRCreation:  true,
+				CommitMsg:          "hello from my PR",
+				CreateMissing:      true,
+				Signature:          s,
+			},
+		},
+	}
+
+	for _, tt := range parseTests {
+		t.Run(fmt.Sprintf("parsing test: %s", tt.testName), func(rt *testing.T) {
+			initViper()
+			makeUpdateCmd()
+			setViperFromTestFlags(tt.flags)
+
+			got := configFromFlags()
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				rt.Errorf("Test %s failed diff\n%s", tt.testName, diff)
+			}
+		})
+	}
+}
+
+func loadRepositoriesFromFile(fileName string, rt *testing.T) (repositories *config.RepoConfiguration) {
+	repositories, err := config.Load(fileName)
+	if err != nil {
+		rt.Errorf("failed to parse testFile %v: %s", fileName, err)
+		return nil
+	}
+	return repositories
+
+}
+
+func setViperFromTestFlags(flags *testFlags) {
+	for f, v := range *flags {
+		viper.Set(f, v)
+	}
+}
+
+func initViper() {
+	viper.Reset()
+	viper.SetEnvPrefix("git")
+	viper.AutomaticEnv()
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,11 +12,13 @@ import (
 // Repository is the items that are required to update a specific file in a repo.
 type Repository struct {
 	Name               string     `json:"name"`
+	Disabled           bool       `json:"disabled,omitempty"`
 	SourceRepo         string     `json:"sourceRepo"`
 	SourceBranch       string     `json:"sourceBranch"`
 	FilePath           string     `json:"filePath"`
 	UpdateKey          string     `json:"updateKey"`
 	BranchGenerateName string     `json:"branchGenerateName"`
+	DisablePRCreation  bool       `json:"disablePRCreation,omitempty"`
 	RemoveKey          bool       `json:"removeKey,omitempty"`
 	RemoveFile         bool       `json:"removeFile,omitempty"`
 	CreateMissing      bool       `json:"createMissing,omitempty"`
@@ -55,15 +57,30 @@ func Parse(in io.Reader) (*RepoConfiguration, error) {
 
 // RepoConfiguration is a slice of Repository values.
 type RepoConfiguration struct {
-	Repositories []*Repository `json:"repositories"`
+	Repositories map[string]*Repository `json:"repositories"`
 }
 
-// Find looks up the repository by name.
-func (c RepoConfiguration) Find(name string) *Repository {
-	for _, cfg := range c.Repositories {
-		if cfg.Name == name {
+// Find looks up the repository by key in a list or RepoConfiguration.Repositories.
+func (c RepoConfiguration) Find(repoKey string) *Repository {
+	for key, cfg := range c.Repositories {
+		if key == repoKey {
 			return cfg
 		}
 	}
 	return nil
+}
+
+// Keys returns the Repository keys in RepoConfiguration.Repositories.
+func (c RepoConfiguration) Keys() []string {
+	var keys []string
+	for key := range c.Repositories {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+// ApplyOverrides will decide if and how to apply cli values when
+// there is a matching config with existing repositories
+func (c RepoConfiguration) ApplyOverrides() RepoConfiguration {
+	return c
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -10,23 +10,23 @@ import (
 
 func TestRepoConfigurationFind(t *testing.T) {
 	findTests := []struct {
-		name string
-		want *Repository
+		repoKey string
+		want    *Repository
 	}{
-		{"testing", &Repository{Name: "testing"}},
+		{"testRepo1", &Repository{Name: "testing"}},
 		{"unknown", nil},
 	}
 
 	cfgs := RepoConfiguration{
-		Repositories: []*Repository{
-			{Name: "testing"},
-			{Name: "another"},
+		Repositories: map[string]*Repository{
+			"testRepo1": {Name: "testing"},
+			"testRepo2": {Name: "another"},
 		},
 	}
 
 	for _, tt := range findTests {
-		if diff := cmp.Diff(tt.want, cfgs.Find(tt.name)); diff != "" {
-			t.Errorf("Find(%s) failed:\n %s", tt.name, diff)
+		if diff := cmp.Diff(tt.want, cfgs.Find(tt.repoKey)); diff != "" {
+			t.Errorf("Find(%s) failed:\n %s", tt.repoKey, diff)
 		}
 	}
 }
@@ -38,8 +38,8 @@ func TestParse(t *testing.T) {
 	}{
 		{
 			"testdata/config.yaml", &RepoConfiguration{
-				Repositories: []*Repository{
-					{
+				Repositories: map[string]*Repository{
+					"testRepo": {
 						Name:               "testing/repo-image",
 						SourceRepo:         "example/example-source",
 						SourceBranch:       "main",
@@ -83,8 +83,8 @@ func TestConfigLoad(t *testing.T) {
 	}{
 		{
 			"testdata/.yaml-updater.yaml", &RepoConfiguration{
-				Repositories: []*Repository{
-					{
+				Repositories: map[string]*Repository{
+					"testRepo1": {
 						Name:               "testing/repo-image",
 						SourceRepo:         "my-org/my-project",
 						SourceBranch:       "main",
@@ -94,7 +94,7 @@ func TestConfigLoad(t *testing.T) {
 						CreateMissing:      true,
 						Signature:          s,
 					},
-					{
+					"testRepo2": {
 						Name:               "testing/repo-image",
 						SourceRepo:         "my-org/my-other-project",
 						SourceBranch:       "master",
@@ -109,8 +109,8 @@ func TestConfigLoad(t *testing.T) {
 		},
 		{
 			"testdata/config.yaml", &RepoConfiguration{
-				Repositories: []*Repository{
-					{
+				Repositories: map[string]*Repository{
+					"testRepo": {
 						Name:               "testing/repo-image",
 						SourceRepo:         "example/example-source",
 						SourceBranch:       "main",

--- a/pkg/config/testdata/config.yaml
+++ b/pkg/config/testdata/config.yaml
@@ -1,5 +1,6 @@
 repositories:
-  - name: testing/repo-image
+  testRepo:
+    name: testing/repo-image
     sourceRepo: example/example-source
     sourceBranch: main
     filePath: test/file.yaml


### PR DESCRIPTION
This commit changes (breaking change) the repositories yaml
configuration so as to allow targeting all, some or unique repositories
for better overrides and simpler automation.

Also:
* PR creation based on flag instead of value (done on ocraviotto/pkg)